### PR TITLE
turn on and off simple services

### DIFF
--- a/etc/vc3-master.conf
+++ b/etc/vc3-master.conf
@@ -14,6 +14,7 @@ httpsport=20334
 
 
 [dynamic]
+builder_path=/afs/nd.edu/user34/btovar/portal/src/vc3/builder/
 plugin=Execute
 # plugin=Openstack
 # plugin=Kubernetes


### PR DESCRIPTION
With the following code, I was able to turn on and off a service (the work queue catalog), sending the following requests to the info service:

on:

{
    "request" : {
        "nd-unua": {
            "work-queue-catalog": {
                "version": "6.0",
                "action":  "spawn"
            }
        }
    }
}

off:
{
    "request" : {
        "nd-unua": {
            "work-queue-catalog": {
                "version": "6.0",
                "action":  "off"
            }
        }
    }
}

I am not too sure about the structure of the code, I probably we will have to rewrite everything as we understand the requirements a little more. But I think this could work as a test bed, or a real demo.
