### PR TITLE
Condor wmsstatus

### DIFF
--- a/vc3master/plugins/task/HandleRequests.py
+++ b/vc3master/plugins/task/HandleRequests.py
@@ -390,7 +390,7 @@ class HandleRequests(VC3Task):
                 config.set(section_name, 'sched.maxtorun.maximum', node_number)
                 config.set(section_name, 'wmsstatusplugin', 'ANY')
                 config.set(section_name, 'wmsstatus.condor.scheddhost', request.headnode)
-             else:
+            else:
                 config.set(section_name, 'sched.keepnrunning.keep_running', node_number)
 
 

--- a/vc3master/plugins/task/HandleRequests.py
+++ b/vc3master/plugins/task/HandleRequests.py
@@ -390,6 +390,7 @@ class HandleRequests(VC3Task):
                 config.set(section_name, 'sched.maxtorun.maximum', node_number)
                 config.set(section_name, 'wmsstatusplugin', 'ANY')
                 config.set(section_name, 'wmsstatus.condor.scheddhost', request.headnode)
+                config.set(section_name, 'wmsstatus.condor.collectorhost', request.headnode)
             else:
                 config.set(section_name, 'sched.keepnrunning.keep_running', node_number)
 

--- a/vc3master/plugins/task/HandleRequests.py
+++ b/vc3master/plugins/task/HandleRequests.py
@@ -341,7 +341,6 @@ class HandleRequests(VC3Task):
         self.log.debug("Information finalized for queues configuration section [%s]. Creating config." % section_name)
 
         config.add_section(section_name)
-        config.set(section_name, 'sched.keepnrunning.keep_running', node_number)
 
         cores  = (resource_nodesize and resource_nodesize.cores)      or 1
         disk   = (resource_nodesize and resource_nodesize.storage_mb) or 1024
@@ -365,12 +364,25 @@ class HandleRequests(VC3Task):
             config.set(section_name, 'executable',                  '%(builder)s')
 
             if nodeset.app_type == 'htcondor' and nodeset.app_role == 'worker-nodes':
+                # add the Condor shared secret
                 try:
                     headnode = self.client.getNodeset(request.headnode)
                     config.set(section_name, 'condor_password_filename', request.name + '-condor.passwd')
                     config.set(section_name, 'condor_password', headnode.app_sectoken)
                 except Exception, e:
                     self.log.warning("Could not get headnode condor password for request '%s'. Continuing without password (this probably won't work).", request.name )
+
+                # configure APF to resize the VC based on the # of jobs in queue
+                scalefactor = 1 / float(len(request.allocations))
+
+                config.set(section_name, 'schedplugin', 'Ready, Scale, KeepNRunning, MaxToRun')
+                config.set(section_name, 'sched.scale.factor', scalefactor)
+                config.set(section_name, 'sched.maxtorun.maximum', node_number)
+                config.set(section_name, 'wmsstatusplugin', 'ANY')
+                config.set(section_name, 'wmsstatus.condor.scheddhost', request.headnode)
+             else:
+                config.set(section_name, 'sched.keepnrunning.keep_running', node_number)
+
 
         elif resource.accesstype == 'cloud':
             config.set(section_name, 'batchsubmitplugin',          'CondorEC2')

--- a/vc3master/plugins/task/HandleRequests.py
+++ b/vc3master/plugins/task/HandleRequests.py
@@ -388,7 +388,8 @@ class HandleRequests(VC3Task):
                 config.set(section_name, 'schedplugin', 'Ready, Scale, KeepNRunning, MaxToRun')
                 config.set(section_name, 'sched.scale.factor', scalefactor)
                 config.set(section_name, 'sched.maxtorun.maximum', node_number)
-                config.set(section_name, 'wmsstatusplugin', 'ANY')
+                config.set(section_name, 'wmsstatusplugin', 'Condor')
+                config.set(section_name, 'wmsqueue', 'ANY')
                 config.set(section_name, 'wmsstatus.condor.scheddhost', request.headnode)
                 config.set(section_name, 'wmsstatus.condor.collectorhost', request.headnode)
             else:


### PR DESCRIPTION
This is a first pass at configuring APF to automatically use the VC3 dynamic headnode with the Condor WMS Status Plugin. We want APF to set the number of running pilots to 0 when there's no work in queue.